### PR TITLE
Update to trixie

### DIFF
--- a/openldap/Dockerfile
+++ b/openldap/Dockerfile
@@ -1,13 +1,17 @@
-FROM ubuntu:22.04
+FROM debian:trixie
 
-# Add Tini
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
 
 # Install OpenLDAP
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y slapd ldap-utils openssl ca-certificates
+RUN bash <<EOF
+set -euo pipefail
+apt update
+export DEBIAN_FRONTEND=noninteractive
+apt install -y \
+      slapd ldap-utils openssl ca-certificates \
+      slapd-contrib tini procps
+apt clean
+rm -rf /var/cache/apt
+EOF
 
 # Copy project files
 COPY resources /app
@@ -16,4 +20,5 @@ COPY resources /app
 WORKDIR /app/
 
 # Run your program under Tini
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/app/entrypoint.sh"]

--- a/openldap/resources/common.sh
+++ b/openldap/resources/common.sh
@@ -14,5 +14,7 @@ fatal(){
 }
 
 start_ldap(){
-  slapd -F /config/slapd.d -u openldap -g openldap -h 'ldap:// ldaps:// ldapi:///' $@
+  mkdir -p /var/run/slapd
+  chown openldap:openldap /var/run/slapd
+  slapd -F /config/slapd.d -u openldap -g openldap -h 'ldap:/// ldaps:/// ldapi:///' $@
 }

--- a/openldap/resources/configure.sh
+++ b/openldap/resources/configure.sh
@@ -110,10 +110,12 @@ info 'Importing LDAP organization'
 ldapmodify -H ldapi:/// -D cn=admin,$ORG_DN -w $ROOT_SECRET -f /tmp/org-init.ldif || fatal 'Could not create organization!'
 
 info 'Importing schemas'
+shopt -s nullglob
 for schema in /app/schema/*.ldif; do
     info "Applying $schema"
     ldapmodify -a -Y EXTERNAL -H ldapi:/// -f $schema || fatal "Could not apply ${schema}!"
 done
+shopt -u nullglob
 
 sleep 1
 kill -s SIGINT $LDAP_PID

--- a/openldap/resources/configure.sh
+++ b/openldap/resources/configure.sh
@@ -125,4 +125,4 @@ touch /config/.configured.flag
 
 # Cleanup
 rm -rf /tmp/*
-rm -rf /etc/ldap
+#rm -rf /etc/ldap

--- a/openldap/resources/entrypoint.sh
+++ b/openldap/resources/entrypoint.sh
@@ -15,6 +15,6 @@ fi
 
 # Start OpenLDAP in foreground
 info "Starting OpenLDAP"
-start_ldap -d 256
+start_ldap -d "${SLAPD_LOG_LEVEL:-256}"
 
 exit 0


### PR DESCRIPTION
- Switches to Debian Trixie
- Updates scripts slightly to make slapd 2.6 run
- Makes ldif import files optional
- Allows passing of slapd log level
- Switches Dockerfile to heredoc style
- Ditches manual tini installation in favour of native package